### PR TITLE
Add stickers support

### DIFF
--- a/signalbot/api.py
+++ b/signalbot/api.py
@@ -11,8 +11,6 @@ class SignalAPI:
         self.signal_service = signal_service
         self.phone_number = phone_number
 
-        # self.session = aiohttp.ClientSession()
-
     async def receive(self):
         try:
             uri = self._receive_ws_uri()
@@ -25,7 +23,11 @@ class SignalAPI:
             raise ReceiveMessagesError(e)
 
     async def send(
-        self, receiver: str, message: str, base64_attachments: list = None
+        self,
+        receiver: str,
+        message: str,
+        sticker: str = None,
+        base64_attachments: list = None,
     ) -> aiohttp.ClientResponse:
         uri = self._send_rest_uri()
         if base64_attachments is None:
@@ -35,6 +37,7 @@ class SignalAPI:
             "message": message,
             "number": self.phone_number,
             "recipients": [receiver],
+            "sticker": sticker,
         }
         try:
             async with aiohttp.ClientSession() as session:

--- a/signalbot/bot.py
+++ b/signalbot/bot.py
@@ -156,12 +156,13 @@ class SignalBot:
         self,
         receiver: str,
         text: str,
+        sticker: str = None,
         base64_attachments: list = None,
         listen: bool = False,
     ) -> int:
         resolved_receiver = self._resolve_receiver(receiver)
         resp = await self._signal.send(
-            resolved_receiver, text, base64_attachments=base64_attachments
+            resolved_receiver, text, sticker, base64_attachments=base64_attachments
         )
         resp_payload = await resp.json()
         timestamp = resp_payload["timestamp"]
@@ -174,6 +175,7 @@ class SignalBot:
                     timestamp=timestamp,
                     type=MessageType.SYNC_MESSAGE,
                     text=text,
+                    sticker=sticker,
                     base64_attachments=base64_attachments,
                     group=None,
                 )
@@ -183,6 +185,7 @@ class SignalBot:
                     timestamp=timestamp,
                     type=MessageType.SYNC_MESSAGE,
                     text=text,
+                    sticker=sticker,
                     base64_attachments=base64_attachments,
                     group=receiver,
                 )

--- a/signalbot/context.py
+++ b/signalbot/context.py
@@ -8,11 +8,16 @@ class Context:
         self.message = message
 
     async def send(
-        self, text: str, base64_attachments: list = None, listen: bool = False
+        self,
+        text: str,
+        sticker: str = None,
+        base64_attachments: list = None,
+        listen: bool = False,
     ):
         await self.bot.send(
             self.message.recipient(),
             text,
+            sticker=sticker,
             base64_attachments=base64_attachments,
             listen=listen,
         )

--- a/signalbot/message.py
+++ b/signalbot/message.py
@@ -14,6 +14,7 @@ class Message:
         timestamp: int,
         type: MessageType,
         text: str,
+        sticker: str = None,
         base64_attachments: list = None,
         group: str = None,
         reaction: str = None,
@@ -25,6 +26,7 @@ class Message:
         self.timestamp = timestamp
         self.type = type
         self.text = text
+        self.sticker = sticker
 
         # optional
         self.base64_attachments = base64_attachments
@@ -96,6 +98,7 @@ class Message:
             timestamp,
             type,
             text,
+            None,
             base64_attachments,
             group,
             reaction,


### PR DESCRIPTION
 Allow bot to send stickers, underlying signal REST API needs to support this (everyone that want to use it can modify signal REST API themselves, API does not support this feature yet)
