### PR TITLE
add text styling support

### DIFF
--- a/example/commands/styles.py
+++ b/example/commands/styles.py
@@ -13,7 +13,7 @@ class StylesCommand(Command):
 if __name__ == "__main__":
     bot = SignalBot({
         "signal_service": os.environ["SIGNAL_SERVICE"],
-        "phone_number": os.environ["PHONE_NUMBER"]
+        "phone_number": os.environ["PHONE_NUMBER"],
     })
     bot.register(StylesCommand()) # all contacts and groups
     bot.start()

--- a/example/commands/styles.py
+++ b/example/commands/styles.py
@@ -1,0 +1,18 @@
+import os
+from signalbot import SignalBot, Command, Context
+
+class StylesCommand(Command):
+    async def handle(self, c: Context):
+        if c.message.text == "Styles":
+            await c.send("**Bold style**", text_mode="styled")
+            await c.send("*Italic style*", text_mode="styled")
+            await c.send("~Strikethrough style~", text_mode="styled")
+            await c.send("`Monospaced style`", text_mode="styled")
+
+if __name__ == "__main__":
+    bot = SignalBot({
+        "signal_service": os.environ["SIGNAL_SERVICE"],
+        "phone_number": os.environ["PHONE_NUMBER"]
+    })
+    bot.register(StylesCommand()) # all contacts and groups
+    bot.start()

--- a/example/commands/styles.py
+++ b/example/commands/styles.py
@@ -7,6 +7,7 @@ class StylesCommand(Command):
             await c.send("**Bold style**", text_mode="styled")
             await c.send("*Italic style*", text_mode="styled")
             await c.send("~Strikethrough style~", text_mode="styled")
+            await c.send("||Spoiler style||", text_mode="styled")            
             await c.send("`Monospaced style`", text_mode="styled")
 
 if __name__ == "__main__":

--- a/signalbot/api.py
+++ b/signalbot/api.py
@@ -34,6 +34,7 @@ class SignalAPI:
         quote_message: str = None,
         quote_timestamp: str = None,
         mentions: list = None,
+        text_mode: str = None,
     ) -> aiohttp.ClientResponse:
         uri = self._send_rest_uri()
         if base64_attachments is None:
@@ -56,6 +57,8 @@ class SignalAPI:
             payload["quote_timestamp"] = quote_timestamp
         if mentions:
             payload["mentions"] = mentions
+        if text_mode:
+            payload["text_mode"] = text_mode
 
         try:
             async with aiohttp.ClientSession() as session:

--- a/signalbot/bot.py
+++ b/signalbot/bot.py
@@ -194,7 +194,7 @@ class SignalBot:
             quote_message=quote_message,
             quote_timestamp=quote_timestamp,
             mentions=mentions,
-            text_mode=text_mode
+            text_mode=text_mode,
         )
         resp_payload = await resp.json()
         timestamp = resp_payload["timestamp"]

--- a/signalbot/bot.py
+++ b/signalbot/bot.py
@@ -181,6 +181,7 @@ class SignalBot:
         quote_message: str = None,
         quote_timestamp: str = None,
         mentions: list = None,
+        text_mode: str = None,
         listen: bool = False,
     ) -> int:
         receiver = self._resolve_receiver(receiver)
@@ -193,6 +194,7 @@ class SignalBot:
             quote_message=quote_message,
             quote_timestamp=quote_timestamp,
             mentions=mentions,
+            text_mode=text_mode
         )
         resp_payload = await resp.json()
         timestamp = resp_payload["timestamp"]

--- a/signalbot/context.py
+++ b/signalbot/context.py
@@ -12,12 +12,14 @@ class Context:
         text: str,
         base64_attachments: list = None,
         mentions: list = None,
+        text_mode: str = None,
     ):
         return await self.bot.send(
             self.message.recipient(),
             text,
             base64_attachments=base64_attachments,
             mentions=mentions,
+            text_mode=text_mode,
         )
 
     async def reply(
@@ -25,6 +27,7 @@ class Context:
         text: str,
         base64_attachments: list = None,
         mentions: list = None,
+        text_mode: str = None,
     ):
         return await self.bot.send(
             self.message.recipient(),
@@ -35,6 +38,7 @@ class Context:
             quote_message=self.message.text,
             quote_timestamp=self.message.timestamp,
             mentions=mentions,
+            text_mode=text_mode,
         )
 
     async def react(self, emoji: str):


### PR DESCRIPTION
Add support for [Signal text styling](https://signal.miraheze.org/wiki/Text_formatting).

In Signal the only way to apply text styling is through the UI, but https://github.com/AsamK/signal-cli supports both reading and setting text styles.
Example from `signal-cli` logs:
```
..., "textStyles":[{"style":"ITALIC", "start":0, "length":5}], ...
```

As you can see also from the text parser in [https://github.com/bbernhard/signal-cli-rest-api](https://github.com/bbernhard/signal-cli-rest-api/blob/7fcb70e673aa7189bfe5330b1e62077ad9d00957/src/utils/textstyleparser.go#L49), text styling through API is realized using familiar markdown:

- `**word**` for **bold**
- `*word*` for *italic*
- `~word~` for ~strikethrough~
- `||word||` for ||spoiler||
- ``` `word` ``` for `monospaced text`

So the styling is done directly in the text using a very small subset of markdown syntax, and it's only necessary to set `text_mode` to **styled** in the payload to enable it.

Since parsing is handled upstream, in `signalbot` I only introduced support for specifying `text_mode="styled"` in the payload when sending messages.

I tested it with a modified [minimal example](https://github.com/filipre/signalbot?tab=readme-ov-file#getting-started):
```
import os
from signalbot import SignalBot, Command, Context

class PingCommand(Command):
    async def handle(self, c: Context):
        if c.message.text == "Ping":
            await c.send("**Pong**", text_mode="styled")
            await c.send("*Pong*", text_mode="styled")
            await c.send("~Pong~", text_mode="styled")
            await c.send("||Pong||", text_mode="styled")
            await c.send("`Pong`", text_mode="styled")

if __name__ == "__main__":
    bot = SignalBot({
        "signal_service": os.environ["SIGNAL_SERVICE"],
        "phone_number": os.environ["PHONE_NUMBER"]
    })
    bot.register(PingCommand()) # all contacts and groups
    bot.start()
```

If `text_mode` is not set, it defaults to `normal` (so without styling).