### PR TITLE
Fix: python 3.9 does not support | syntax for union

### DIFF
--- a/signalbot/bot.py
+++ b/signalbot/bot.py
@@ -338,8 +338,8 @@ class SignalBot:
     def _should_react_for_contact(
         self,
         message: Message,
-        contacts: list[str] | bool,
-        group_ids: list[str] | bool,
+        contacts: Union[list[str], bool],
+        group_ids: Union[list[str], bool],
     ):
         """Is the command activated for a certain chat or group?"""
 
@@ -379,7 +379,7 @@ class SignalBot:
     def _should_react_for_lambda(
         self,
         message: Message,
-        f: Callable[[Message], bool] | None,
+        f: Optional[Callable[[Message], bool]] = None,
     ) -> bool:
         if f is None:
             return True


### PR DESCRIPTION
Running the code on Python 3.9 gives the error:
`TypeError: unsupported operand type(s) for |: 'types.GenericAlias' and 'type'`

The fix is to use `Union` and `Optional` as is done elsewhere in the file.