### PR TITLE
Add support for read receipts.

### DIFF
--- a/signalbot/api.py
+++ b/signalbot/api.py
@@ -93,6 +93,26 @@ class SignalAPI:
         ):
             raise ReactionError
 
+    async def receipt(
+        self, recipient: str, receipt_type: str, target_author: str, timestamp: int
+    ) -> aiohttp.ClientResponse:
+        uri = self._receipt_rest_uri()
+        payload = {
+            "recipient": recipient,
+            "receipt_type": receipt_type,
+            "timestamp": timestamp,
+        }
+        try:
+            async with aiohttp.ClientSession() as session:
+                resp = await session.post(uri, json=payload)
+                resp.raise_for_status()
+                return resp
+        except (
+            aiohttp.ClientError,
+            aiohttp.http_exceptions.HttpProcessingError,
+        ):
+            raise ReactionError
+
     async def start_typing(self, receiver: str):
         uri = self._typing_indicator_uri()
         payload = {
@@ -149,6 +169,9 @@ class SignalAPI:
 
     def _typing_indicator_uri(self):
         return f"http://{self.signal_service}/v1/typing-indicator/{self.phone_number}"
+
+    def _receipt_rest_uri(self):
+        return f"http://{self.signal_service}/v1/receipts/{self.phone_number}"
 
     def _groups_uri(self):
         return f"http://{self.signal_service}/v1/groups/{self.phone_number}"

--- a/signalbot/bot.py
+++ b/signalbot/bot.py
@@ -214,6 +214,19 @@ class SignalBot:
         await self._signal.react(recipient, emoji, target_author, timestamp)
         logging.info(f"[Bot] New reaction: {emoji}")
 
+    async def receipt(self, message: Message, receipt_type: str):
+        recipient = message.recipient()
+
+        # can't do groups yet because not supported in signal-cli
+        if getattr(message, 'group'):
+            return
+
+        recipient = self._resolve_receiver(recipient)
+        target_author = message.source
+        timestamp = message.timestamp
+        await self._signal.receipt(recipient, receipt_type, target_author, timestamp)
+        logging.info(f"[Bot] Receipt: {receipt_type}")
+
     async def start_typing(self, receiver: str):
         receiver = self._resolve_receiver(receiver)
         await self._signal.start_typing(receiver)

--- a/signalbot/context.py
+++ b/signalbot/context.py
@@ -44,6 +44,9 @@ class Context:
     async def react(self, emoji: str):
         await self.bot.react(self.message, emoji)
 
+    async def receipt(self, receipt_type: str):
+        await self.bot.receipt(self.message, receipt_type)
+
     async def start_typing(self):
         await self.bot.start_typing(self.message.recipient())
 


### PR DESCRIPTION
Read receipts for individual messages are available in https://github.com/bbernhard/signal-cli-rest-api/pull/534. This adds support via `Context.receipt("read")`.