### PR TITLE
Improve error message if handle() method not implemented in Command.

### DIFF
--- a/signalbot/bot.py
+++ b/signalbot/bot.py
@@ -413,8 +413,11 @@ class SignalBot:
         try:
             context = Context(self, message)
             await command.handle(context)
+        except NotImplementedError as e:
+            logging.error(f"[{command.__class__.__name__}] Error: handle() method not implemented")
+            raise e
         except Exception as e:
-            logging.error(f"[{command.__class__.__name__}] Error: {e}")
+            logging.error(f"[{command.__class__.__name__}] {e.__class__} Error: {e}")
             raise e
 
         # done


### PR DESCRIPTION
Small quality of life improvement that prevents an unhelpful error if you have a typo in the `handle()` method (and spent longer than you should have wondering what wasn't working).

Was:
`ERROR:root:[TestCommand] Error: `

Now:
`ERROR:root:[TestCommand] Error: handle() method not implemented`