### PR TITLE
Improved storage capabilities

### DIFF
--- a/signalbot/storage.py
+++ b/signalbot/storage.py
@@ -4,6 +4,9 @@ from typing import Any
 
 
 class Storage:
+    def __init__(self):
+        self.redis = None
+
     def exists(self, key: str) -> bool:
         raise NotImplementedError
 
@@ -57,14 +60,14 @@ class InMemoryStorage(Storage):
 
 class RedisStorage(Storage):
     def __init__(self, host, port):
-        self._redis = redis.Redis(host=host, port=port, db=0)
+        self.redis = redis.Redis(host=host, port=port, db=0)
 
     def exists(self, key: str) -> bool:
-        return self._redis.exists(key)
+        return self.redis.exists(key)
 
     def read(self, key: str) -> Any:
         try:
-            result_bytes = self._redis.get(key)
+            result_bytes = self.redis.get(key)
             result_str = result_bytes.decode("utf-8")
             result_dict = json.loads(result_str)
             return result_dict
@@ -73,13 +76,13 @@ class RedisStorage(Storage):
 
     def delete(self, *keys: str) -> int:
         try:
-            return self._redis.delete(*keys)
+            return self.redis.delete(*keys)
         except Exception as e:
             raise StorageError(f"Redis delete failed: {e}")
 
     def save(self, key: str, object: Any):
         try:
             object_str = json.dumps(object)
-            self._redis.set(key, object_str)
+            self.redis.set(key, object_str)
         except Exception as e:
             raise StorageError(f"Redis save failed: {e}")

--- a/signalbot/storage.py
+++ b/signalbot/storage.py
@@ -10,6 +10,9 @@ class Storage:
     def read(self, key: str) -> Any:
         raise NotImplementedError
 
+    def delete(self, *keys: str) -> int:
+        raise NotImplementedError
+
     def save(self, key: str, object: Any):
         raise NotImplementedError
 
@@ -32,6 +35,17 @@ class InMemoryStorage(Storage):
             return result_dict
         except Exception as e:
             raise StorageError(f"InMemory load failed: {e}")
+
+    def delete(self, *keys: str) -> int:
+        try:
+            deleted_count = 0
+            for key in keys:
+                if key in self._storage:
+                    del self._storage[key]
+                    deleted_count += 1
+            return deleted_count
+        except Exception as e:
+            raise StorageError(f"InMemory delete failed: {e}")
 
     def save(self, key: str, object: Any):
         try:
@@ -56,6 +70,12 @@ class RedisStorage(Storage):
             return result_dict
         except Exception as e:
             raise StorageError(f"Redis load failed: {e}")
+
+    def delete(self, *keys: str) -> int:
+        try:
+            return self._redis.delete(*keys)
+        except Exception as e:
+            raise StorageError(f"Redis delete failed: {e}")
 
     def save(self, key: str, object: Any):
         try:


### PR DESCRIPTION
because the current implementation of `storage.read()` or `storage.save()` do not work well when they run simultaneously i moved the `_redis` from storage class to `redis`.
now the entire redis class is available within the storage class.
furthermore `storage.delete()` is now a thing.

i have a command that fetches content from a website. this takes time.
to make sure a user never receives the same post twice i used to:

1. storage.read()
2. do stuff
3. storage_result.append(new_id)
4. storage.save()

if the user runs the same command twice in a row it might happen that both coroutines read the same data and only the last one is actually saved.

now this is possible:
```py
if c.bot.storage.redis is not None: # 'None' is default if storage is not redis
    c.bot.storage.redis.smembers(storage_key) # use redis.Redis().smembers() - list the set of stored data
    c.bot.storage.redis.sadd(storage_key, item["id"]) # use redis.Redis().sadd() - add item to the end of the existing data
```

p.s.: sorry to spam your repo. i messed up my git settings... new pc and stuff...