### PR TITLE
Make command an abstract class

### DIFF
--- a/signalbot/command.py
+++ b/signalbot/command.py
@@ -1,4 +1,5 @@
 import functools
+from abc import ABC, abstractmethod
 
 from .message import Message
 from .context import Context
@@ -27,7 +28,7 @@ def triggered(*by, case_sensitive=False):
     return decorator_triggered
 
 
-class Command:
+class Command(ABC):
     # optional
     def setup(self):
         pass
@@ -37,8 +38,9 @@ class Command:
         return None
 
     # overwrite
+    @abstractmethod
     async def handle(self, context: Context):
-        raise NotImplementedError
+        pass
 
     # helper method
     # deprecated: please use @triggered

--- a/signalbot/utils/__init__.py
+++ b/signalbot/utils/__init__.py
@@ -1,5 +1,6 @@
 from .chat_testing import (
     ChatTestCase,
+    DummyCommand,
     SendMessagesMock,
     ReceiveMessagesMock,
     ReactMessageMock,
@@ -8,6 +9,7 @@ from .chat_testing import (
 
 __all__ = [
     "ChatTestCase",
+    "DummyCommand",
     "SendMessagesMock",
     "ReceiveMessagesMock",
     "ReactMessageMock",

--- a/signalbot/utils/chat_testing.py
+++ b/signalbot/utils/chat_testing.py
@@ -6,7 +6,7 @@ import functools
 import aiohttp
 from unittest.mock import AsyncMock, MagicMock
 
-from ..bot import SignalBot
+from ..bot import SignalBot, Command, Context
 
 from unittest.mock import patch
 
@@ -131,3 +131,8 @@ class ReactMessageMock(AsyncMock):
         for args in self.call_args_list:
             results.append(args[0])
         return results
+
+
+class DummyCommand(Command):
+    async def handle(self, context: Context):
+        pass

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2,6 +2,8 @@ import unittest
 import asyncio
 from unittest.mock import patch, AsyncMock
 from signalbot import SignalBot, Command, SignalAPI
+from signalbot.context import Context
+from signalbot.utils import DummyCommand
 
 
 class BotTestCase(unittest.IsolatedAsyncioTestCase):
@@ -35,8 +37,8 @@ class TestProducer(BotTestCase):
         )
         self.signal_bot.listen(TestProducer.group_id, TestProducer.internal_id)
         # Any two commands
-        self.signal_bot.register(Command())
-        self.signal_bot.register(Command())
+        self.signal_bot.register(DummyCommand())
+        self.signal_bot.register(DummyCommand())
 
         await self.signal_bot._produce(1337)
 
@@ -99,13 +101,13 @@ class TestListenUser(BotTestCase):
 
 class TestRegisterCommand(BotTestCase):
     def test_register_one_command(self):
-        self.signal_bot.register(Command())
+        self.signal_bot.register(DummyCommand())
         self.assertEqual(len(self.signal_bot.commands), 1)
 
     def test_register_three_commands(self):
-        self.signal_bot.register(Command())
-        self.signal_bot.register(Command())
-        self.signal_bot.register(Command())
+        self.signal_bot.register(DummyCommand())
+        self.signal_bot.register(DummyCommand())
+        self.signal_bot.register(DummyCommand())
         self.assertEqual(len(self.signal_bot.commands), 3)
 
     def test_register_calls_setup_of_command(self):
@@ -115,6 +117,9 @@ class TestRegisterCommand(BotTestCase):
 
             def setup(self):
                 self.state = True
+
+            def handle(self, context: Context):
+                pass
 
         cmd = SomeTestCommand()
         self.assertEqual(cmd.state, False)


### PR DESCRIPTION
Command is an abstract class and it's more idiomatic to declare it as such. I spent half an hour chasing an empty named exception because the method of one of my commands was not named `handle`. With this PR a `Command` instance raises an error on instantiation, usually when calling the `bot.register()` function if it is missing the `handle` method.