### PR TITLE
Add comment to explain how to use mentions

### DIFF
--- a/signalbot/api.py
+++ b/signalbot/api.py
@@ -1,5 +1,6 @@
 import aiohttp
 import websockets
+from typing import Any
 
 
 class SignalAPI:
@@ -33,7 +34,7 @@ class SignalAPI:
         quote_mentions: list = None,
         quote_message: str = None,
         quote_timestamp: str = None,
-        mentions: list = None,
+        mentions: list[dict[str, Any]] | None = None,
         text_mode: str = None,
     ) -> aiohttp.ClientResponse:
         uri = self._send_rest_uri()

--- a/signalbot/bot.py
+++ b/signalbot/bot.py
@@ -4,7 +4,7 @@ import time
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 import logging
 import traceback
-from typing import Optional, Union, List, Callable
+from typing import Optional, Union, List, Callable, Any
 import re
 import uuid
 
@@ -181,7 +181,8 @@ class SignalBot:
         quote_mentions: list = None,
         quote_message: str = None,
         quote_timestamp: str = None,
-        mentions: list = None,
+        mentions: list[dict[str, Any]]
+        | None = None,  # [{ "author": "uuid" , "start": 0, "length": 1 }]
         text_mode: str = None,
         listen: bool = False,
     ) -> int:

--- a/signalbot/bot.py
+++ b/signalbot/bot.py
@@ -181,8 +181,9 @@ class SignalBot:
         quote_mentions: list = None,
         quote_message: str = None,
         quote_timestamp: str = None,
-        mentions: list[dict[str, Any]]
-        | None = None,  # [{ "author": "uuid" , "start": 0, "length": 1 }]
+        mentions: (
+            list[dict[str, Any]] | None
+        ) = None,  # [{ "author": "uuid" , "start": 0, "length": 1 }]
         text_mode: str = None,
         listen: bool = False,
     ) -> int:

--- a/signalbot/context.py
+++ b/signalbot/context.py
@@ -1,5 +1,6 @@
 # from .bot import Signalbot # TODO: figure out how to enable this for typing
 from .message import Message
+from typing import Any
 
 
 class Context:
@@ -26,7 +27,8 @@ class Context:
         self,
         text: str,
         base64_attachments: list = None,
-        mentions: list = None,
+        mentions: list[dict[str, Any]]
+        | None = None,  # [{ "author": "uuid" , "start": 0, "length": 1 }]
         text_mode: str = None,
     ):
         return await self.bot.send(

--- a/signalbot/context.py
+++ b/signalbot/context.py
@@ -27,8 +27,9 @@ class Context:
         self,
         text: str,
         base64_attachments: list = None,
-        mentions: list[dict[str, Any]]
-        | None = None,  # [{ "author": "uuid" , "start": 0, "length": 1 }]
+        mentions: (
+            list[dict[str, Any]] | None
+        ) = None,  # [{ "author": "uuid" , "start": 0, "length": 1 }]
         text_mode: str = None,
     ):
         return await self.bot.send(


### PR DESCRIPTION
This PR adds a comment that explains how to use mentions. See #76 for why this is useful.
