### PR TITLE
re-fetch group information

### DIFF
--- a/signalbot/bot.py
+++ b/signalbot/bot.py
@@ -342,6 +342,13 @@ class SignalBot:
                 except UnknownMessageFormatError:
                     continue
 
+                # Update groups if message is from an unknown group
+                if (
+                    message.is_group()
+                    and self._groups_by_internal_id.get(message.group) is None
+                ):
+                    await self._detect_groups()
+
                 await self._ask_commands_to_handle(message)
 
         except ReceiveMessagesError as e:


### PR DESCRIPTION
The bot cannot reply to groups if it was added after startup, since the receiver lookup fails.

Instead of periodically refreshing the groups, the commit checks the group while receiving new messages.
If the group is unknown, `_detect_groups()` is called before passing the message on.

