### PR TITLE
Refactor: Preserve Raw Message in Message Parser

### DIFF
--- a/signalbot/message.py
+++ b/signalbot/message.py
@@ -69,9 +69,9 @@ class Message:
         return bool(self.group)
 
     @classmethod
-    async def parse(cls, signal: SignalAPI, raw_message: str):
+    async def parse(cls, signal: SignalAPI, raw_message_str: str):
         try:
-            raw_message = json.loads(raw_message)
+            raw_message = json.loads(raw_message_str)
         except Exception:
             raise UnknownMessageFormatError
 
@@ -130,7 +130,7 @@ class Message:
             group,
             reaction,
             mentions,
-            raw_message,
+            raw_message_str,
         )
 
     @classmethod


### PR DESCRIPTION
Updated the `parse` method to ensure that raw_message refers to the original unprocessed message received by the parser.

This avoids unintended transformations, preventing the need for explicit casting when accessing `raw_message`. Renamed `raw_message` parameter to `raw_message_str` to clarify its nature before JSON deserialization.