### PR TITLE
fix: parse attachments for sync messages, fixes #88

### DIFF
--- a/signalbot/message.py
+++ b/signalbot/message.py
@@ -98,8 +98,12 @@ class Message:
             mentions = cls._parse_mentions(
                 raw_message["envelope"]["syncMessage"]["sentMessage"]
             )
-            base64_attachments = None
-            attachments_local_filenames = None
+            base64_attachments = await cls._parse_attachments(
+                signal, raw_message["envelope"]["syncMessage"]["sentMessage"]
+            )
+            attachments_local_filenames = cls._parse_attachments_local_filenames(
+                raw_message["envelope"]["syncMessage"]["sentMessage"]
+            )
 
         # Option 2: dataMessage
         elif "dataMessage" in raw_message["envelope"]:


### PR DESCRIPTION
I couldn't get the bot to receive any sync messages. According to the [signalcli API docs](https://github.com/AsamK/signal-cli/blob/master/man/signal-cli-dbus.5.adoc#signals), sync messages are sent from linked devices. However, I was still receiving data messages from linked devices. So I couldn't test this PR.