### PR TITLE
:sparkles: Allow using username as receiver

### DIFF
--- a/signalbot/bot.py
+++ b/signalbot/bot.py
@@ -316,6 +316,7 @@ class SignalBot:
         Usernames may only contain a-z, 0-9 and _.
         You must include at least two digits at the end of your username.
         There cannot be more than 9 digits at the of your username.
+        Digits cannnot be 00.
         """
         split_username = receiver_username.split('.')
         if len(split_username) == 2:

--- a/signalbot/bot.py
+++ b/signalbot/bot.py
@@ -275,6 +275,9 @@ class SignalBot:
         if self._is_valid_uuid(receiver):
             return receiver
 
+        if self._is_username(receiver):
+            return receiver
+
         if self._is_group_id(receiver):
             return receiver
 
@@ -304,6 +307,34 @@ class SignalBot:
             uuid.UUID(str(receiver_uuid))
             return True
         except ValueError:
+            return False
+
+    def _is_username(self, receiver_username: str):
+        """
+        Check if username has correct format.
+        Usernames can be between 3 and 32 characters.
+        Usernames may only contain a-z, 0-9 and _.
+        You must include at least two digits at the end of your username.
+        There cannot be more than 9 digits at the of your username.
+        """
+        split_username = receiver_username.split('.')
+        if len(split_username) == 2:
+            characters = split_username[0]
+            digits = split_username[1]
+            if len(characters) < 3 or len(characters) > 32:
+                return False
+            if not re.match(r'^[A-Za-z\d_]+$', characters):
+                return False
+            if len(digits) < 2 or len(digits) > 9:
+                return False
+            try:
+                digits = int(digits)
+                if digits == 0:
+                    return False
+                return True
+            except ValueError:
+                return False
+        else:
             return False
 
     def _is_group_id(self, group_id: str) -> bool:

--- a/signalbot/bot.py
+++ b/signalbot/bot.py
@@ -309,7 +309,7 @@ class SignalBot:
         except ValueError:
             return False
 
-    def _is_username(self, receiver_username: str):
+    def _is_username(self, receiver_username: str) -> bool:
         """
         Check if username has correct format.
         Usernames can be between 3 and 32 characters.

--- a/signalbot/bot.py
+++ b/signalbot/bot.py
@@ -311,12 +311,8 @@ class SignalBot:
 
     def _is_username(self, receiver_username: str) -> bool:
         """
-        Check if username has correct format.
-        Usernames can be between 3 and 32 characters.
-        Usernames may only contain a-z, 0-9 and _.
-        You must include at least two digits at the end of your username.
-        There cannot be more than 9 digits at the of your username.
-        Digits cannnot be 00.
+        Check if username has correct format, as described in https://support.signal.org/hc/en-us/articles/6712070553754-Phone-Number-Privacy-and-Usernames#username_req
+        Additionally, cannot have more than 9 digits and the digits cannot be 00.
         """
         split_username = receiver_username.split(".")
         if len(split_username) == 2:

--- a/signalbot/bot.py
+++ b/signalbot/bot.py
@@ -318,13 +318,13 @@ class SignalBot:
         There cannot be more than 9 digits at the of your username.
         Digits cannnot be 00.
         """
-        split_username = receiver_username.split('.')
+        split_username = receiver_username.split(".")
         if len(split_username) == 2:
             characters = split_username[0]
             digits = split_username[1]
             if len(characters) < 3 or len(characters) > 32:
                 return False
-            if not re.match(r'^[A-Za-z\d_]+$', characters):
+            if not re.match(r"^[A-Za-z\d_]+$", characters):
                 return False
             if len(digits) < 2 or len(digits) > 9:
                 return False

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -127,6 +127,7 @@ class TestUsernameValidation(BotTestCase):
 
     def test_invalid_username(self):
         self.assertFalse(self.signal_bot._is_username("Us.99"))
+        self.assertFalse(self.signal_bot._is_username("Usr.9"))
         self.assertFalse(self.signal_bot._is_username(".UserName99"))
         self.assertFalse(self.signal_bot._is_username(".UserName.99"))
         self.assertFalse(self.signal_bot._is_username("UserName99"))

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -119,6 +119,10 @@ class TestUsernameValidation(BotTestCase):
         self.assertTrue(self.signal_bot._is_username("username.999999999"))
         self.assertTrue(self.signal_bot._is_username("UserName99.99"))
         self.assertTrue(self.signal_bot._is_username("_Use_rName99_.99"))
+        self.assertTrue(self.signal_bot._is_username("username.999999999"))
+        self.assertTrue(
+            self.signal_bot._is_username("usernameeeeeeeeeeeeeeeeeeeeeeeee.999999999")
+        )
 
     def test_invalid_username(self):
         self.assertFalse(self.signal_bot._is_username(".UserName99"))
@@ -130,6 +134,9 @@ class TestUsernameValidation(BotTestCase):
         self.assertFalse(self.signal_bot._is_username("UserName99.0"))
         self.assertFalse(self.signal_bot._is_username("UserName99.00"))
         self.assertFalse(self.signal_bot._is_username("UserName99.000000000"))
+        self.assertFalse(
+            self.signal_bot._is_username(".usernameeeeeeeeeeeeeeeeeeeeeeeeee.99")
+        )
 
 
 class TestRegisterCommand(BotTestCase):

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -115,6 +115,7 @@ class TestListenUser(BotTestCase):
 
 class TestUsernameValidation(BotTestCase):
     def test_valid_username(self):
+        self.assertTrue(self.signal_bot._is_username("Usr.99"))
         self.assertTrue(self.signal_bot._is_username("UserName.99"))
         self.assertTrue(self.signal_bot._is_username("username.999999999"))
         self.assertTrue(self.signal_bot._is_username("UserName99.99"))
@@ -125,6 +126,7 @@ class TestUsernameValidation(BotTestCase):
         )
 
     def test_invalid_username(self):
+        self.assertFalse(self.signal_bot._is_username("Us.99"))
         self.assertFalse(self.signal_bot._is_username(".UserName99"))
         self.assertFalse(self.signal_bot._is_username(".UserName.99"))
         self.assertFalse(self.signal_bot._is_username("UserName99"))

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -122,7 +122,7 @@ class TestUsernameValidation(BotTestCase):
             "UserName99.99",
             "_Use_rName99_.99",
             "username.999999999",
-            "usernameeeeeeeeeeeeeeeeeeeeeeeee.999999999"
+            "usernameeeeeeeeeeeeeeeeeeeeeeeee.999999999",
         ]
         for valid_username in valid_usernames:
             self.assertTrue(self.signal_bot._is_username(valid_username))
@@ -140,7 +140,7 @@ class TestUsernameValidation(BotTestCase):
             "UserName99.0",
             "UserName99.00",
             "UserName99.000000000",
-            ".usernameeeeeeeeeeeeeeeeeeeeeeeeee.99"
+            ".usernameeeeeeeeeeeeeeeeeeeeeeeeee.99",
         ]
         for invalid_username in invalid_usernames:
             self.assertFalse(self.signal_bot._is_username(invalid_username))

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -113,6 +113,25 @@ class TestListenUser(BotTestCase):
         self.assertSetEqual(self.signal_bot.user_chats, expected_user_chats)
 
 
+class TestUsernameValidation(BotTestCase):
+    def test_valid_username(self):
+        self.assertTrue(self.signal_bot._is_username("UserName.99"))
+        self.assertTrue(self.signal_bot._is_username("username.999999999"))
+        self.assertTrue(self.signal_bot._is_username("UserName99.99"))
+        self.assertTrue(self.signal_bot._is_username("_Use_rName99_.99"))
+
+    def test_invalid_username(self):
+        self.assertFalse(self.signal_bot._is_username(".UserName99"))
+        self.assertFalse(self.signal_bot._is_username(".UserName.99"))
+        self.assertFalse(self.signal_bot._is_username("UserName99"))
+        self.assertFalse(self.signal_bot._is_username("UserName99."))
+        self.assertFalse(self.signal_bot._is_username("username.9999999999"))
+        self.assertFalse(self.signal_bot._is_username("user@name.999"))
+        self.assertFalse(self.signal_bot._is_username("UserName99.0"))
+        self.assertFalse(self.signal_bot._is_username("UserName99.00"))
+        self.assertFalse(self.signal_bot._is_username("UserName99.000000000"))
+
+
 class TestRegisterCommand(BotTestCase):
     def test_register_one_command(self):
         self.signal_bot.register(DummyCommand())

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -115,31 +115,35 @@ class TestListenUser(BotTestCase):
 
 class TestUsernameValidation(BotTestCase):
     def test_valid_username(self):
-        self.assertTrue(self.signal_bot._is_username("Usr.99"))
-        self.assertTrue(self.signal_bot._is_username("UserName.99"))
-        self.assertTrue(self.signal_bot._is_username("username.999999999"))
-        self.assertTrue(self.signal_bot._is_username("UserName99.99"))
-        self.assertTrue(self.signal_bot._is_username("_Use_rName99_.99"))
-        self.assertTrue(self.signal_bot._is_username("username.999999999"))
-        self.assertTrue(
-            self.signal_bot._is_username("usernameeeeeeeeeeeeeeeeeeeeeeeee.999999999")
-        )
+        valid_usernames = [
+            "Usr.99",
+            "UserName.99",
+            "username.999999999",
+            "UserName99.99",
+            "_Use_rName99_.99",
+            "username.999999999",
+            "usernameeeeeeeeeeeeeeeeeeeeeeeee.999999999"
+        ]
+        for valid_username in valid_usernames:
+            self.assertTrue(self.signal_bot._is_username(valid_username))
 
     def test_invalid_username(self):
-        self.assertFalse(self.signal_bot._is_username("Us.99"))
-        self.assertFalse(self.signal_bot._is_username("Usr.9"))
-        self.assertFalse(self.signal_bot._is_username(".UserName99"))
-        self.assertFalse(self.signal_bot._is_username(".UserName.99"))
-        self.assertFalse(self.signal_bot._is_username("UserName99"))
-        self.assertFalse(self.signal_bot._is_username("UserName99."))
-        self.assertFalse(self.signal_bot._is_username("username.9999999999"))
-        self.assertFalse(self.signal_bot._is_username("user@name.999"))
-        self.assertFalse(self.signal_bot._is_username("UserName99.0"))
-        self.assertFalse(self.signal_bot._is_username("UserName99.00"))
-        self.assertFalse(self.signal_bot._is_username("UserName99.000000000"))
-        self.assertFalse(
-            self.signal_bot._is_username(".usernameeeeeeeeeeeeeeeeeeeeeeeeee.99")
-        )
+        invalid_usernames = [
+            "Us.99",
+            "Usr.9",
+            ".UserName99",
+            ".UserName.99",
+            "UserName99",
+            "UserName99.",
+            "username.9999999999",
+            "user@name.999",
+            "UserName99.0",
+            "UserName99.00",
+            "UserName99.000000000",
+            ".usernameeeeeeeeeeeeeeeeeeeeeeeeee.99"
+        ]
+        for invalid_username in invalid_usernames:
+            self.assertFalse(self.signal_bot._is_username(invalid_username))
 
 
 class TestRegisterCommand(BotTestCase):


### PR DESCRIPTION
 Allow using username as receiver.
 Validation is done as per signal requirements - [here](https://support.signal.org/hc/en-us/articles/6712070553754-Phone-Number-Privacy-and-Usernames)
 Additional validation is checking if there are no more than 9 digits and the digits are not 00 at the end of username, since signal does not allow it but does not mention it in the requirements.