### PR TITLE
fix: remove deprecation warning from github actions

### DIFF
--- a/.github/workflows/deploy-pr.yaml
+++ b/.github/workflows/deploy-pr.yaml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Create custom version
         id: create-custom-version
-        run: echo "::set-output name=pr_version::$(poetry version -s)a$(date +%s)"
+        run: echo "{pr_version}=$(poetry version -s)a$(date +%s)" >> $GITHUB_OUTPUT
 
       - name: Set new version
         run: poetry version ${{ steps.create-custom-version.outputs.pr_version }}

--- a/.github/workflows/deploy-pr.yaml
+++ b/.github/workflows/deploy-pr.yaml
@@ -105,7 +105,7 @@ jobs:
         run: poetry publish -r testpypi
 
       - name: Write comment in Pull Request
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
         run: poetry install --no-dev
       - name: Get Package Version
         id: get-version
-        run: echo "::set-output name=package_version::$(poetry version -s)"
+        run: echo "{package_version}=$(poetry version -s)" >> $GITHUB_OUTPUT
       - name: Build package
         run: poetry build
       - name: Add test.pypi.org to Poetry
@@ -63,7 +63,7 @@ jobs:
         run: poetry install --no-dev
       - name: Get Package Version
         id: get-version
-        run: echo "::set-output name=package_version::$(poetry version -s)"
+        run: echo "{package_version}=$(poetry version -s)" >> $GITHUB_OUTPUT
       - name: Build package
         run: poetry build
       - name: Add pypi.org to Poetry


### PR DESCRIPTION
Follow more modern practices for setting the output of the step as described here https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/