### PR TITLE
Add optional config to prevent attachments download

### DIFF
--- a/signalbot/api.py
+++ b/signalbot/api.py
@@ -11,13 +11,14 @@ class SignalAPI:
         self,
         signal_service: str,
         phone_number: str,
+        download_attachments: bool = True
     ):
         self.phone_number = phone_number
         self._signal_api_uris = SignalAPIURIs(
             signal_service=signal_service,
             phone_number=phone_number,
         )
-
+        self.download_attachments = download_attachments
         # self.session = aiohttp.ClientSession()
 
     async def receive(self):

--- a/signalbot/api.py
+++ b/signalbot/api.py
@@ -8,10 +8,7 @@ from typing import Literal
 
 class SignalAPI:
     def __init__(
-        self,
-        signal_service: str,
-        phone_number: str,
-        download_attachments: bool = True
+        self, signal_service: str, phone_number: str, download_attachments: bool = True
     ):
         self.phone_number = phone_number
         self._signal_api_uris = SignalAPIURIs(

--- a/signalbot/bot.py
+++ b/signalbot/bot.py
@@ -40,6 +40,7 @@ class SignalBot:
             redis_host: "redis"
             redis_port: 6379
         retry_interval: 1
+        download_attachments: True
         """
         self.config = config
 
@@ -58,7 +59,8 @@ class SignalBot:
         try:
             self._phone_number = self.config["phone_number"]
             self._signal_service = self.config["signal_service"]
-            self._signal = SignalAPI(self._signal_service, self._phone_number)
+            download_attachments = self.config.get("download_attachments", True)
+            self._signal = SignalAPI(self._signal_service, self._phone_number, download_attachments)
         except KeyError:
             raise SignalBotError("Could not initialize SignalAPI with given config")
 

--- a/signalbot/bot.py
+++ b/signalbot/bot.py
@@ -60,7 +60,9 @@ class SignalBot:
             self._phone_number = self.config["phone_number"]
             self._signal_service = self.config["signal_service"]
             download_attachments = self.config.get("download_attachments", True)
-            self._signal = SignalAPI(self._signal_service, self._phone_number, download_attachments)
+            self._signal = SignalAPI(
+                self._signal_service, self._phone_number, download_attachments
+            )
         except KeyError:
             raise SignalBotError("Could not initialize SignalAPI with given config")
 

--- a/signalbot/message.py
+++ b/signalbot/message.py
@@ -100,10 +100,10 @@ class Message:
             )
             base64_attachments = await cls._parse_attachments(
                 signal, raw_message["envelope"]["syncMessage"]["sentMessage"]
-            )
+            ) if signal.download_attachments else []
             attachments_local_filenames = cls._parse_attachments_local_filenames(
                 raw_message["envelope"]["syncMessage"]["sentMessage"]
-            )
+            ) if signal.download_attachments else []
 
         # Option 2: dataMessage
         elif "dataMessage" in raw_message["envelope"]:
@@ -114,10 +114,10 @@ class Message:
             mentions = cls._parse_mentions(raw_message["envelope"]["dataMessage"])
             base64_attachments = await cls._parse_attachments(
                 signal, raw_message["envelope"]["dataMessage"]
-            )
+            ) if signal.download_attachments else []
             attachments_local_filenames = cls._parse_attachments_local_filenames(
                 raw_message["envelope"]["dataMessage"]
-            )
+            ) if signal.download_attachments else []
 
         else:
             raise UnknownMessageFormatError

--- a/signalbot/message.py
+++ b/signalbot/message.py
@@ -98,12 +98,20 @@ class Message:
             mentions = cls._parse_mentions(
                 raw_message["envelope"]["syncMessage"]["sentMessage"]
             )
-            base64_attachments = await cls._parse_attachments(
-                signal, raw_message["envelope"]["syncMessage"]["sentMessage"]
-            ) if signal.download_attachments else []
-            attachments_local_filenames = cls._parse_attachments_local_filenames(
-                raw_message["envelope"]["syncMessage"]["sentMessage"]
-            ) if signal.download_attachments else []
+            base64_attachments = (
+                await cls._parse_attachments(
+                    signal, raw_message["envelope"]["syncMessage"]["sentMessage"]
+                )
+                if signal.download_attachments
+                else []
+            )
+            attachments_local_filenames = (
+                cls._parse_attachments_local_filenames(
+                    raw_message["envelope"]["syncMessage"]["sentMessage"]
+                )
+                if signal.download_attachments
+                else []
+            )
 
         # Option 2: dataMessage
         elif "dataMessage" in raw_message["envelope"]:
@@ -112,12 +120,20 @@ class Message:
             group = cls._parse_group_information(raw_message["envelope"]["dataMessage"])
             reaction = cls._parse_reaction(raw_message["envelope"]["dataMessage"])
             mentions = cls._parse_mentions(raw_message["envelope"]["dataMessage"])
-            base64_attachments = await cls._parse_attachments(
-                signal, raw_message["envelope"]["dataMessage"]
-            ) if signal.download_attachments else []
-            attachments_local_filenames = cls._parse_attachments_local_filenames(
-                raw_message["envelope"]["dataMessage"]
-            ) if signal.download_attachments else []
+            base64_attachments = (
+                await cls._parse_attachments(
+                    signal, raw_message["envelope"]["dataMessage"]
+                )
+                if signal.download_attachments
+                else []
+            )
+            attachments_local_filenames = (
+                cls._parse_attachments_local_filenames(
+                    raw_message["envelope"]["dataMessage"]
+                )
+                if signal.download_attachments
+                else []
+            )
 
         else:
             raise UnknownMessageFormatError


### PR DESCRIPTION
Hi, 

can you add the following optional configuration to prevent auto-download of attachments? (by default I kept it enabled so no impact on existing users I think)

Reasoning:
For most of my bots I don't really need to parse attachments, just text message data so disabling the auto-download saves server bandwidth considerably in a long run and, depending on groups number, could also decrease bot startup time. 