### PR TITLE
fix: When read message

### DIFF
--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -14,6 +14,7 @@ class TestMessage(unittest.IsolatedAsyncioTestCase):
     raw_reaction_message = '{"envelope":{"source":"<source>","sourceNumber":"<source>","sourceUuid":"<uuid>","sourceName":"<name>","sourceDevice":1,"timestamp":1632576001632,"syncMessage":{"sentMessage":{"timestamp":1632576001632,"message":null,"expiresInSeconds":0,"viewOnce":false,"reaction":{"emoji":"👍","targetAuthor":"<target>","targetAuthorNumber":"<target>","targetAuthorUuid":"<uuid>","targetSentTimestamp":1632576001632,"isRemove":false},"mentions":[],"attachments":[],"contacts":[],"groupInfo":{"groupId":"<groupid>","type":"DELIVER"},"destination":null,"destinationNumber":null,"destinationUuid":null}}}}'  # noqa: E501
     raw_user_chat_message = '{"envelope":{"source":"+490123456789","sourceNumber":"+490123456789","sourceUuid":"<uuid>","sourceName":"<name>","sourceDevice":1,"timestamp":1632576001632,"dataMessage":{"timestamp":1632576001632,"message":"Uhrzeit","expiresInSeconds":0,"viewOnce":false}},"account":"+49987654321","subscription":0}'  # noqa: E501
     raw_attachment_message = '{"envelope":{"source":"+490123456789","sourceNumber":"+490123456789","sourceUuid":"<uuid>","sourceName":"<name>","sourceDevice":1,"timestamp":1632576001632,"dataMessage":{"timestamp":1632576001632,"message":"Uhrzeit","expiresInSeconds":0,"viewOnce":false, "attachments": [{"contentType": "image/png", "filename": "image.png", "id": "1qeCjjWOOo9Gxv8pfdCw.png","size": 12005}]}},"account":"+49987654321","subscription":0}'  # noqa: E501
+    raw_user_read_message = '{"envelope":{"source":"+490123456789","sourceNumber":"+490123456789","sourceUuid":"<uuid>","sourceName":"<name>","sourceDevice":1,"timestamp":1632576001632,"serverReceivedTimestamp":1632576001632,"serverDeliveredTimestamp":1632576001632,"syncMessage":{"readMessages":[{"sender":"+49987654321","senderNumber":"+49987654321","senderUuid":"<uuid>","timestamp":1632576001632}]}},"account":"+49987654321"}'  # noqa: E501
 
     expected_source = "+490123456789"
     expected_timestamp = 1632576001632
@@ -115,6 +116,22 @@ class TestMessage(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(message.text, TestMessage.expected_text)  # noqa: PT009
         self.assertEqual(message.timestamp, TestMessage.expected_timestamp)  # noqa: PT009
         self.assertIsNone(message.group)  # noqa: PT009
+
+    async def test_message_read(self):
+        message = await Message.parse(
+            self.signal_api, TestMessage.raw_user_read_message
+        )
+
+        self.assertEqual(message.type, MessageType.READ_MESSAGE)  # noqa: PT009
+        self.assertEqual(message.text, "")  # noqa: PT009
+        self.assertIsInstance(message.read_messages, list)  # noqa: PT009
+        self.assertEqual(len(message.read_messages), 1)  # noqa: PT009
+
+        rm = message.read_messages[0]
+        self.assertEqual(rm.get("sender"), "+49987654321")  # noqa: PT009
+        self.assertEqual(rm.get("senderNumber"), "+49987654321")  # noqa: PT009
+        self.assertEqual(rm.get("timestamp"), TestMessage.expected_timestamp)  # noqa: PT009
+        self.assertIn("senderUuid", rm)  # noqa: PT009
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
An other bug like #173, after updating the bot and the API, my bot ended up with new messages (it seems) and the signalbot code itself doesn't know how to handle them:

```log
signal-bot-1  | INFO:signalbot:[Bot] Producer #1 started
signal-bot-1  | INFO:signalbot:[Raw Message] {"envelope":{"source":"+490123456789","sourceNumber":"+490123456789","sourceUuid":"<uuid>","sourceName":"<name>","sourceDevice":1,"timestamp":1632576001632,"serverReceivedTimestamp":1632576001632,"serverDeliveredTimestamp":1632576001632,"syncMessage":{"readMessages":[{"sender":"+49987654321","senderNumber":"+49987654321","senderUuid":"<uuid>","timestamp":1632576001632}]}},"account":"+49987654321"}
signal-bot-1  | Traceback (most recent call last):
signal-bot-1  |   File "/usr/local/lib/python3.14/site-packages/signalbot/bot.py", line 450, in _rerun_on_exception
signal-bot-1  |     return await coro(*args, **kwargs)
signal-bot-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
signal-bot-1  |   File "/usr/local/lib/python3.14/site-packages/signalbot/bot.py", line 497, in _produce
signal-bot-1  |     message = await Message.parse(self._signal, raw_message)
signal-bot-1  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
signal-bot-1  |   File "/usr/local/lib/python3.14/site-packages/signalbot/message.py", line 127, in parse
signal-bot-1  |     data_message = sync_message["sentMessage"]
signal-bot-1  |                    ~~~~~~~~~~~~^^^^^^^^^^^^^^^
signal-bot-1  | KeyError: 'sentMessage'
signal-bot-1  | WARNING:signalbot:Restarting coroutine in 2 seconds
```

The event was fired when I read a message, but there is not `sentMessage` in `syncMessage`, there is `readMessages`.

### Changes

Add MessageType `READ_MESSAGE`
Add class-field read_messages
Return earlier than other MessageType, because this is not really a message
Add a unit test