### PR TITLE
fix: make LinkPreview.description optional to handle None values

### DIFF
--- a/signalbot/link_previews.py
+++ b/signalbot/link_previews.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 class LinkPreview(BaseModel):
     base64_thumbnail: str
     title: str
-    description: str
+    description: str | None = None
     url: str
 
     #  This is the local filename for a received link preview


### PR DESCRIPTION
Signal API can return None for link preview descriptions, causing Pydantic validation errors. Changed description field from required string to optional (str | None = None) to match API behavior.

Fixes crash when receiving messages with link previews lacking descriptions.

## How to Reproduce
1. Send a message to a Signal group with a URL that generates a link preview
2. The URL must be one where Signal's metadata service returns None for the description field
3. The bot will crash when trying to parse the message

## Root Cause
In `signalbot/link_previews.py`, the LinkPreview model defines:

```python
class LinkPreview(BaseModel):
    base64_thumbnail: str
    title: str
    description: str  # Required field
    url: str
    id: str | None = None
```

The description field is required to be a string, but Signal's API can legitimately send `None` for this field when no description is available for a URL.

## Fix
Make the description field optional:

```python
description: str | None = None
```

## Impact
- **Before**: Bot crashes on any message with link preview lacking description
- **After**: Bot handles all link previews gracefully, with or without descriptions

## Testing
Tested with messages containing:
- Link previews with descriptions ✅
- Link previews without descriptions ✅
- Messages without link previews ✅