### PR TITLE
fix: resolve SIM103 and TRY300 linter errors

### DIFF
--- a/src/signalbot/bot.py
+++ b/src/signalbot/bot.py
@@ -552,9 +552,10 @@ class SignalBot:
     def _is_valid_uuid(self, receiver_uuid: str) -> bool:
         try:
             uuid.UUID(str(receiver_uuid))
-            return True  # noqa: TRY300
         except ValueError:
             return False
+        else:
+            return True
 
     def _is_username(self, receiver_username: str) -> bool:  # noqa: PLR0911
         """
@@ -574,11 +575,10 @@ class SignalBot:
                 return False
             try:
                 digits = int(digits)
-                if digits == 0:  # noqa: SIM103
-                    return False
-                return True  # noqa: TRY300
             except ValueError:
                 return False
+            else:
+                return digits != 0
         else:
             return False
 


### PR DESCRIPTION
## Summary

This PR fixes some of the linter errors mentioned in #167.

## Changes

Fixed the following ruff linter errors:

1. **SIM103** (in  method):
   - Before: `if digits == 0: return False; return True`
   - After: `return digits != 0`

2. **TRY300** (in `_is_valid_uuid` and `_is_username` methods):
   - Moved return statements from try block to else clause

## Code Changes

### `_is_valid_uuid` method
```python
# Before
def _is_valid_uuid(self, receiver_uuid: str) -> bool:
    try:
        uuid.UUID(str(receiver_uuid))
        return True  # noqa: TRY300
    except ValueError:
        return False

# After
def _is_valid_uuid(self, receiver_uuid: str) -> bool:
    try:
        uuid.UUID(str(receiver_uuid))
    except ValueError:
        return False
    else:
        return True
```

### `_is_username` method
```python
# Before
try:
    digits = int(digits)
    if digits == 0:  # noqa: SIM103
        return False
    return True  # noqa: TRY300
except ValueError:
    return False

# After
try:
    digits = int(digits)
except ValueError:
    return False
else:
    return digits != 0
```

Partially addresses #167