### PR TITLE
docs: add reaction examples and API reference

### DIFF
--- a/docs/examples/api_overview.md
+++ b/docs/examples/api_overview.md
@@ -49,6 +49,13 @@ Check the [commands section](#commands) to see the implementation of each comman
 </details>
 
 
+<details><summary>ReactionCommand & ThumbsUpCommand</summary>
+``` python
+--8<-- "examples/commands/reaction.py"
+```
+</details>
+
+
 <details><summary>RegexTriggeredCommand</summary>
 ``` python
 --8<-- "examples/commands/regex_triggered.py"

--- a/docs/reference/reaction.md
+++ b/docs/reference/reaction.md
@@ -1,0 +1,3 @@
+::: signalbot.reaction
+    options:
+      merge_init_into_class: false

--- a/examples/bot.py
+++ b/examples/bot.py
@@ -8,10 +8,12 @@ from examples.commands import (
     EditCommand,
     HelpCommand,
     PingCommand,
+    ReactionCommand,
     ReceiveDeleteCommand,
     RegexTriggeredCommand,
     ReplyCommand,
     StylesCommand,
+    ThumbsUpCommand,
     TriggeredCommand,
     TypingCommand,
 )
@@ -46,6 +48,8 @@ def main() -> None:
     bot.register(TriggeredCommand(), contacts=["+490123456789"], groups=True)
 
     bot.register(RegexTriggeredCommand())
+    bot.register(ReactionCommand())
+    bot.register(ThumbsUpCommand())
 
     bot.register(EditCommand())
     bot.register(DeleteCommand())

--- a/examples/commands/__init__.py
+++ b/examples/commands/__init__.py
@@ -4,6 +4,7 @@ from .edit import EditCommand
 from .help import HelpCommand
 from .multiple_triggered import TriggeredCommand
 from .ping import PingCommand
+from .reaction import ReactionCommand, ThumbsUpCommand
 from .regex_triggered import RegexTriggeredCommand
 from .reply import ReplyCommand
 from .styles import StylesCommand
@@ -16,10 +17,12 @@ __all__ = [
     "EditCommand",
     "HelpCommand",
     "PingCommand",
+    "ReactionCommand",
     "ReceiveDeleteCommand",
     "RegexTriggeredCommand",
     "ReplyCommand",
     "StylesCommand",
+    "ThumbsUpCommand",
     "TriggeredCommand",
     "TypingCommand",
 ]

--- a/examples/commands/reaction.py
+++ b/examples/commands/reaction.py
@@ -1,0 +1,27 @@
+from examples.commands.help import CommandWithHelpMessage
+from signalbot import Context, reaction_triggered
+
+
+class ReactionCommand(CommandWithHelpMessage):
+    def help_message(self) -> str:
+        return "react with any emoji: 👍 Reaction decorator example."
+
+    @reaction_triggered()
+    async def handle(self, context: Context) -> None:
+        reaction = context.message.reaction
+        if reaction.is_remove:
+            await context.send(f"You removed your {reaction.emoji} reaction")
+            return
+        await context.send(
+            f"{reaction.emoji} from {context.message.source} "
+            f"on message at {reaction.target_sent_timestamp}"
+        )
+
+
+class ThumbsUpCommand(CommandWithHelpMessage):
+    def help_message(self) -> str:
+        return "react with 👍 or ❤️: 🎯 Filtered reaction decorator example."
+
+    @reaction_triggered("👍", "❤️")
+    async def handle(self, context: Context) -> None:
+        await context.send("Thanks for the love!")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
     - LinkPreview: reference/linkpreview.md
     - Command: reference/command.md
     - Quote: reference/quote.md
+    - Reaction: reference/reaction.md
   - Troubleshooting: troubleshooting.md
   - Contributing: local_development.md
 


### PR DESCRIPTION
Add ReactionCommand and ThumbsUpCommand examples demonstrating reaction_triggered decorator usage with metadata access and emoji filtering. Add Reaction model reference page and wire into mkdocs nav.

## Description

Link to issue(s) if appropiate

## Checklist
- [x] Describe your changes
- [x] Add unit tests, both for new features or for bug fixes
- [x] The unit test pass `uv run pytest`
- [x] Prek is installed `uv run prek install`
- [x] The prek checks pass `uv run prek run --all-files`
