### PR TITLE
feat: add redis_password support

### DIFF
--- a/src/signalbot/bot.py
+++ b/src/signalbot/bot.py
@@ -151,7 +151,9 @@ class SignalBot:
             self._logger.info("sqlite storage initilized")
         elif isinstance(self.config.storage, RedisConfig):
             self.storage = RedisStorage(
-                self.config.storage.redis_host, self.config.storage.redis_port
+                self.config.storage.redis_host,
+                self.config.storage.redis_port,
+                self.config.storage.redis_password,
             )
             self._logger.info("redis storage initilized")
         elif isinstance(self.config.storage, InMemoryConfig):

--- a/src/signalbot/bot_config.py
+++ b/src/signalbot/bot_config.py
@@ -18,11 +18,13 @@ class RedisConfig(BaseModel):
         type: The type of storage.
         redis_host: The hostname of the Redis server.
         redis_port: The port number of the Redis server.
+        redis_password: The password for Redis authentication. Defaults to `None`.
     """
 
     type: Literal["redis"] = "redis"
     redis_host: str
     redis_port: int
+    redis_password: str | None = None
 
 
 class SQLiteConfig(BaseModel):

--- a/src/signalbot/storage.py
+++ b/src/signalbot/storage.py
@@ -79,8 +79,8 @@ class SQLiteStorage(Storage):
 
 
 class RedisStorage(Storage):
-    def __init__(self, host: str, port: int):  # noqa: ANN204
-        self._redis = redis.Redis(host=host, port=port, db=0)
+    def __init__(self, host: str, port: int, password: str | None = None):  # noqa: ANN204
+        self._redis = redis.Redis(host=host, port=port, db=0, password=password)
 
     def exists(self, key: str) -> bool:
         return self._redis.exists(key)

--- a/tests/test_bot_config.py
+++ b/tests/test_bot_config.py
@@ -61,7 +61,7 @@ class TestLoadConfig:
         config = load_config(self._dict_config)
         assert isinstance(config, Config)
         assert isinstance(config.storage, RedisConfig)
-        assert config.storage.redis_password == "secret"
+        assert config.storage.redis_password == "secret"  # noqa: S105
 
     def test_load_config_from_json_file(self):
         self._config.retry_interval = 3

--- a/tests/test_bot_config.py
+++ b/tests/test_bot_config.py
@@ -49,6 +49,19 @@ class TestLoadConfig:
         assert isinstance(config, Config)
         assert isinstance(config.storage, RedisConfig)
         assert config.storage.redis_host == "redis_host"
+        assert config.storage.redis_password is None
+
+    def test_load_config_from_dict_with_redis_password(self):
+        self._dict_config["storage"] = {
+            "type": "redis",
+            "redis_host": "redis_host",
+            "redis_port": 6379,
+            "redis_password": "secret",
+        }
+        config = load_config(self._dict_config)
+        assert isinstance(config, Config)
+        assert isinstance(config.storage, RedisConfig)
+        assert config.storage.redis_password == "secret"
 
     def test_load_config_from_json_file(self):
         self._config.retry_interval = 3

--- a/tests/test_bot_config.py
+++ b/tests/test_bot_config.py
@@ -56,12 +56,12 @@ class TestLoadConfig:
             "type": "redis",
             "redis_host": "redis_host",
             "redis_port": 6379,
-            "redis_password": "secret",  # noqa: S105
+            "redis_password": "secret",
         }
         config = load_config(self._dict_config)
         assert isinstance(config, Config)
         assert isinstance(config.storage, RedisConfig)
-        assert config.storage.redis_password == "secret"  # noqa: S105
+        assert config.storage.redis_password == "secret"
 
     def test_load_config_from_json_file(self):
         self._config.retry_interval = 3

--- a/tests/test_bot_config.py
+++ b/tests/test_bot_config.py
@@ -56,12 +56,12 @@ class TestLoadConfig:
             "type": "redis",
             "redis_host": "redis_host",
             "redis_port": 6379,
-            "redis_password": "secret",
+            "redis_password": "secret",  # noqa: S105
         }
         config = load_config(self._dict_config)
         assert isinstance(config, Config)
         assert isinstance(config.storage, RedisConfig)
-        assert config.storage.redis_password == "secret"
+        assert config.storage.redis_password == "secret"  # noqa: S105
 
     def test_load_config_from_json_file(self):
         self._config.retry_interval = 3

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,39 @@
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+
+def _make_mock_redis_module():
+    """Return a fake redis module with a Redis class."""
+    mock_redis_mod = ModuleType("redis")
+    mock_redis_mod.Redis = MagicMock()
+    return mock_redis_mod
+
+
+class TestRedisStorage:
+    def test_init_without_password(self):
+        mock_redis_mod = _make_mock_redis_module()
+        with patch.dict(sys.modules, {"redis": mock_redis_mod}):
+            # Re-import so the module picks up the mocked redis
+            import importlib
+
+            import signalbot.storage as storage_mod
+
+            importlib.reload(storage_mod)
+            storage_mod.RedisStorage(host="localhost", port=6379)
+            mock_redis_mod.Redis.assert_called_once_with(
+                host="localhost", port=6379, db=0, password=None
+            )
+
+    def test_init_with_password(self):
+        mock_redis_mod = _make_mock_redis_module()
+        with patch.dict(sys.modules, {"redis": mock_redis_mod}):
+            import importlib
+
+            import signalbot.storage as storage_mod
+
+            importlib.reload(storage_mod)
+            storage_mod.RedisStorage(host="localhost", port=6379, password="secret")
+            mock_redis_mod.Redis.assert_called_once_with(
+                host="localhost", port=6379, db=0, password="secret"
+            )

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -33,7 +33,7 @@ class TestRedisStorage:
             import signalbot.storage as storage_mod
 
             importlib.reload(storage_mod)
-            storage_mod.RedisStorage(host="localhost", port=6379, password="secret")
+            storage_mod.RedisStorage(host="localhost", port=6379, password="secret")  # noqa: S105
             mock_redis_mod.Redis.assert_called_once_with(
-                host="localhost", port=6379, db=0, password="secret"
+                host="localhost", port=6379, db=0, password="secret"  # noqa: S105
             )

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
+
+import importlib
 import sys
 from types import ModuleType
 from unittest.mock import MagicMock, patch
 
+import signalbot.storage as storage_mod
 
-def _make_mock_redis_module():
+
+def _make_mock_redis_module() -> ModuleType:
     """Return a fake redis module with a Redis class."""
     mock_redis_mod = ModuleType("redis")
     mock_redis_mod.Redis = MagicMock()
@@ -14,11 +19,6 @@ class TestRedisStorage:
     def test_init_without_password(self):
         mock_redis_mod = _make_mock_redis_module()
         with patch.dict(sys.modules, {"redis": mock_redis_mod}):
-            # Re-import so the module picks up the mocked redis
-            import importlib
-
-            import signalbot.storage as storage_mod
-
             importlib.reload(storage_mod)
             storage_mod.RedisStorage(host="localhost", port=6379)
             mock_redis_mod.Redis.assert_called_once_with(
@@ -28,10 +28,6 @@ class TestRedisStorage:
     def test_init_with_password(self):
         mock_redis_mod = _make_mock_redis_module()
         with patch.dict(sys.modules, {"redis": mock_redis_mod}):
-            import importlib
-
-            import signalbot.storage as storage_mod
-
             importlib.reload(storage_mod)
             storage_mod.RedisStorage(host="localhost", port=6379, password="secret")  # noqa: S105
             mock_redis_mod.Redis.assert_called_once_with(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -31,5 +31,8 @@ class TestRedisStorage:
             importlib.reload(storage_mod)
             storage_mod.RedisStorage(host="localhost", port=6379, password="secret")  # noqa: S106
             mock_redis_mod.Redis.assert_called_once_with(
-                host="localhost", port=6379, db=0, password="secret"  # noqa: S106
+                host="localhost",
+                port=6379,
+                db=0,
+                password="secret",  # noqa: S106
             )

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -29,7 +29,7 @@ class TestRedisStorage:
         mock_redis_mod = _make_mock_redis_module()
         with patch.dict(sys.modules, {"redis": mock_redis_mod}):
             importlib.reload(storage_mod)
-            storage_mod.RedisStorage(host="localhost", port=6379, password="secret")  # noqa: S105
+            storage_mod.RedisStorage(host="localhost", port=6379, password="secret")  # noqa: S106
             mock_redis_mod.Redis.assert_called_once_with(
-                host="localhost", port=6379, db=0, password="secret"  # noqa: S105
+                host="localhost", port=6379, db=0, password="secret"  # noqa: S106
             )


### PR DESCRIPTION
## Summary

Adds optional `redis_password` support so bots can connect to password-protected Redis instances.

## Changes

- **`src/signalbot/bot_config.py`**: `RedisConfig` gains an optional `redis_password: str | None = None` field with docstring.
- **`src/signalbot/storage.py`**: `RedisStorage.__init__` accepts an optional `password` parameter, forwarded to `redis.Redis()`.
- **`src/signalbot/bot.py`**: Passes `config.storage.redis_password` when constructing `RedisStorage`.

## Usage

```python
bot = SignalBot(
    Config(
        signal_service="127.0.0.1:8080",
        phone_number="+49123456789",
        storage=RedisConfig(
            redis_host="redis",
            redis_port=6379,
            redis_password="your_password",
        ),
    )
)
```

The field is optional — existing configs without `redis_password` continue to work unchanged (defaults to `None`, which means no authentication).

🤖 Generated with [Claude Code](https://claude.com/claude-code)