### PR TITLE
Add storage classes to API reference

### DIFF
--- a/docs/additional_information.md
+++ b/docs/additional_information.md
@@ -7,7 +7,9 @@ It does not have any handlers attached, for convenience the [signalbot.enable_co
 
 By default the storage attribute of the [signalbot.SignalBot][] class is in-memory.
 Any changes are lost when the bot is stopped or reseted.
-For persistent storage to disk, check the SQLite or Redis storage [page](./examples/bot_config_options.md#storage-type-options).
+For persistent storage, see the [SQLiteStorage][signalbot.storage.SQLiteStorage] and
+[RedisStorage][signalbot.storage.RedisStorage] API references and the
+[storage configuration examples](./examples/bot_config_options.md#storage-type-options).
 
 ## Authentication
 

--- a/docs/examples/bot_config_options.md
+++ b/docs/examples/bot_config_options.md
@@ -94,7 +94,7 @@ storage:
 ### SQLite
 
 Persists data to a local SQLite database.
-Have a look at the [SQLiteStorage](https://github.com/signalbot-org/signalbot/blob/b2a2ec15c3632580230e004455815ce509c2666d/src/signalbot/storage.py#L39) class for how to store and retrive the data.
+See the [SQLiteStorage][signalbot.storage.SQLiteStorage] API reference for details.
 
 ```yaml title="config.yml"
 signal_service: "http://localhost:8080"
@@ -107,7 +107,7 @@ storage:
 ### Redis
 
 Persists data to Redis database.
-Have a look at the [RedisStorage](https://github.com/signalbot-org/signalbot/blob/b2a2ec15c3632580230e004455815ce509c2666d/src/signalbot/storage.py#L81) class for how to store and retrive the data.
+See the [RedisStorage][signalbot.storage.RedisStorage] API reference for details.
 
 ```yaml title="config.yml"
 signal_service: "http://localhost:8080"

--- a/docs/reference/storage.md
+++ b/docs/reference/storage.md
@@ -1,0 +1,9 @@
+# Storage
+
+::: signalbot.storage.SQLiteStorage
+    options:
+      show_root_heading: true
+
+::: signalbot.storage.RedisStorage
+    options:
+      show_root_heading: true

--- a/docs/reference/storage.md
+++ b/docs/reference/storage.md
@@ -1,5 +1,8 @@
 # Storage
 
+Signalbot uses in-memory storage by default. To configure a persistent backend,
+see the [storage configuration examples](../examples/bot_config_options.md#storage-type-options).
+
 ::: signalbot.storage.SQLiteStorage
     options:
       show_root_heading: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ nav:
       - Config: reference/bot_config.md
       - Message: reference/message.md
       - Context: reference/context.md
+      - Storage: reference/storage.md
       - LinkPreview: reference/linkpreview.md
       - Command: reference/command.md
       - Quote: reference/quote.md


### PR DESCRIPTION
## Description

Fixes #249.

Adds a dedicated Storage API reference page for `SQLiteStorage` and
`RedisStorage`, and links it from the reference navigation. The strict MkDocs
build confirms that both class names and constructor documentation are rendered.

## Checklist

- [x] Describe your changes
- [x] Add unit tests, both for new features or for bug fixes — N/A: this is a documentation-only change
- [x] The unit test pass `uv run pytest` (86 passed)
- [x] Prek is installed `uv run prek install`
- [x] The prek checks pass `uv run prek run --all-files`

## Documentation test

- `uv run mkdocs build --strict`
